### PR TITLE
Add type def for getTextInputRefs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -19,6 +19,15 @@ interface KeyboardAwareProps {
    * @memberof KeyboardAwareProps
    */
   innerRef?: (ref: JSX.Element) => void
+  
+  /**
+   * Array of TextInput used to scroll in to view on focus.
+   *
+   * @type {function}
+   * @memberof KeyboardAwareProps
+   */
+  getTextInputRefs?: () => React.MutableRefObject<TextInput | null>[]
+  
   /**
    * Adds an extra offset that represents the TabBarIOS height.
    *


### PR DESCRIPTION
Add type def for getTextInputRefs to KeyboardAwareProps. Not 100% sure on this but is working for me and resolves the missing prop type.